### PR TITLE
Fixed javascript function destroywindow(), prevent the multiple usage of the same element ID.

### DIFF
--- a/global/host/dam/js/global.js
+++ b/global/host/dam/js/global.js
@@ -37,7 +37,7 @@ function showwindow(theurl,thetitle,thew,thewin) {
 // Destroy Window
 function destroywindow(numb) {
 	try{
-		$('#thewindowcontent' + numb).dialog('destroy');
+		$('#thewindowcontent' + numb).dialog('destroy').empty();
 	}
 	catch(e) {};
 }


### PR DESCRIPTION
Fixes the following issue:

Once an Asset is added via detail view to an collection, assets can not be added to a collection in folder view.

If an Asset is added via detail view to a collection, there is still a (hidden) div container (#thewindowcontent2) with a child div container (#div_choosecol). Now if the user tries to add assets from folder view to a collection there will be created a new div container (#thewindowcontent1) which also contains a div container with element id #div_choosecol. So there are two elements with the same id at the same time and the browser can't handle it.

In consequence the user is not able to select the target collection, because the selection is send to the other (hidden) container #div_choosecol. 

This tiny fix will remove all childs of the dialog containers to prevent multiple elements with the same id at the same time.